### PR TITLE
Changes in comments and const usage

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -46,7 +46,7 @@ void SetParametersForLinearSmoothing(int boundary, int fft_size, int fs,
     frequency_axis[i] = static_cast<double>(i) / fft_size *
     fs - width / 2.0;
 }
-}
+}  // namespace
 
 //-----------------------------------------------------------------------------
 // Fundamental functions

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -147,7 +147,7 @@ void InitializeForwardRealFFT(int fft_size, ForwardRealFFT *forward_real_fft) {
       forward_real_fft->waveform, forward_real_fft->spectrum, FFT_ESTIMATE);
 }
 
-void DestroyForwardRealFFT(const ForwardRealFFT *forward_real_fft) {
+void DestroyForwardRealFFT(ForwardRealFFT *forward_real_fft) {
   fft_destroy_plan(forward_real_fft->forward_fft);
   delete[] forward_real_fft->spectrum;
   delete[] forward_real_fft->waveform;
@@ -161,7 +161,7 @@ void InitializeInverseRealFFT(int fft_size, InverseRealFFT *inverse_real_fft) {
       inverse_real_fft->spectrum, inverse_real_fft->waveform, FFT_ESTIMATE);
 }
 
-void DestroyInverseRealFFT(const InverseRealFFT *inverse_real_fft) {
+void DestroyInverseRealFFT(InverseRealFFT *inverse_real_fft) {
   fft_destroy_plan(inverse_real_fft->inverse_fft);
   delete[] inverse_real_fft->spectrum;
   delete[] inverse_real_fft->waveform;
@@ -220,7 +220,7 @@ void GetMinimumPhaseSpectrum(const MinimumPhaseAnalysis *minimum_phase) {
   }
 }
 
-void DestroyMinimumPhaseAnalysis(const MinimumPhaseAnalysis *minimum_phase) {
+void DestroyMinimumPhaseAnalysis(MinimumPhaseAnalysis *minimum_phase) {
   fft_destroy_plan(minimum_phase->forward_fft);
   fft_destroy_plan(minimum_phase->inverse_fft);
   delete[] minimum_phase->cepstrum;

--- a/src/common.h
+++ b/src/common.h
@@ -87,17 +87,17 @@ void NuttallWindow(int y_length, double *y);
 // These functions are used to speed up the processing.
 // Forward FFT
 void InitializeForwardRealFFT(int fft_size, ForwardRealFFT *forward_real_fft);
-void DestroyForwardRealFFT(const ForwardRealFFT *forward_real_fft);
+void DestroyForwardRealFFT(ForwardRealFFT *forward_real_fft);
 
 // Inverse FFT
 void InitializeInverseRealFFT(int fft_size, InverseRealFFT *inverse_real_fft);
-void DestroyInverseRealFFT(const InverseRealFFT *inverse_real_fft);
+void DestroyInverseRealFFT(InverseRealFFT *inverse_real_fft);
 
 // Minimum phase analysis (This analysis uses FFT)
 void InitializeMinimumPhaseAnalysis(int fft_size,
   MinimumPhaseAnalysis *minimum_phase);
 void GetMinimumPhaseSpectrum(const MinimumPhaseAnalysis *minimum_phase);
-void DestroyMinimumPhaseAnalysis(const MinimumPhaseAnalysis *minimum_phase);
+void DestroyMinimumPhaseAnalysis(MinimumPhaseAnalysis *minimum_phase);
 
 WORLD_END_C_DECLS
 

--- a/src/dio.cpp
+++ b/src/dio.cpp
@@ -510,7 +510,7 @@ void GetF0Candidates(const ZeroCrossings *zero_crossings, double boundary_f0,
 //-----------------------------------------------------------------------------
 // DestroyZeroCrossings() frees the memory of array in the struct
 //-----------------------------------------------------------------------------
-void DestroyZeroCrossings(const ZeroCrossings *zero_crossings) {
+void DestroyZeroCrossings(ZeroCrossings *zero_crossings) {
   delete[] zero_crossings->negative_interval_locations;
   delete[] zero_crossings->positive_interval_locations;
   delete[] zero_crossings->peak_interval_locations;

--- a/src/matlabfunctions.cpp
+++ b/src/matlabfunctions.cpp
@@ -261,7 +261,7 @@ double randn(void) {
   return tmp / 268435456.0 - 6.0;
 }
 
-void fast_fftfilt(const double *x, int x_length, double *h, int h_length,
+void fast_fftfilt(const double *x, int x_length, const double *h, int h_length,
     int fft_size, const ForwardRealFFT *forward_real_fft,
     const InverseRealFFT *inverse_real_fft, double *y) {
   fft_complex *x_spectrum = new fft_complex[fft_size];


### PR DESCRIPTION
This pull request is mostly "aesthetical".

I added a comment to the closing bracket of anonymous namespace in common.cpp, as it is done in all the others files.

I removed const keyword in functions that destroy the content of structures. While using const is syntactically correct, it does not seem semantically correct to me, as the pointers address will be invalid after usage.

The only real fix is in matlabfunctions.cpp, where the implementation of fast_fftfilt did not match the prototype defined in matlabfunctions.h.