### PR TITLE
Use static linkage in addition to anonymous namespace

### DIFF
--- a/src/cheaptrick.cpp
+++ b/src/cheaptrick.cpp
@@ -18,7 +18,7 @@ namespace {
 // SmoothingWithRecovery() carries out the spectral smoothing and spectral
 // recovery on the Cepstrum domain.
 //-----------------------------------------------------------------------------
-void SmoothingWithRecovery(double current_f0, int fs, int fft_size, double q1,
+static void SmoothingWithRecovery(double current_f0, int fs, int fft_size, double q1,
     const ForwardRealFFT *forward_real_fft,
     const InverseRealFFT *inverse_real_fft, double *spectral_envelope) {
 // We can control q1 as the parameter. 2015/9/22 by M. Morise
@@ -62,7 +62,7 @@ void SmoothingWithRecovery(double current_f0, int fs, int fft_size, double q1,
 // DC stands for Direct Current. In this case, the component from 0 to F0 Hz
 // is corrected.
 //-----------------------------------------------------------------------------
-void GetPowerSpectrum(int fs, double current_f0, int fft_size,
+static void GetPowerSpectrum(int fs, double current_f0, int fft_size,
     const ForwardRealFFT *forward_real_fft) {
   int half_window_length = matlab_round(1.5 * fs / current_f0);
 
@@ -85,7 +85,7 @@ void GetPowerSpectrum(int fs, double current_f0, int fft_size,
 //-----------------------------------------------------------------------------
 // SetParametersForGetWindowedWaveform()
 //-----------------------------------------------------------------------------
-void SetParametersForGetWindowedWaveform(int half_window_length, int x_length,
+static void SetParametersForGetWindowedWaveform(int half_window_length, int x_length,
     double temporal_position, int fs, double current_f0, int *base_index,
     int *index, double *window) {
   for (int i = -half_window_length; i <= half_window_length; ++i)
@@ -110,7 +110,7 @@ void SetParametersForGetWindowedWaveform(int half_window_length, int x_length,
 //-----------------------------------------------------------------------------
 // GetWindowedWaveform() windows the waveform by F0-adaptive window
 //-----------------------------------------------------------------------------
-void GetWindowedWaveform(const double *x, int x_length, int fs,
+static void GetWindowedWaveform(const double *x, int x_length, int fs,
     double current_f0, double temporal_position,
     const ForwardRealFFT *forward_real_fft) {
   int half_window_length = matlab_round(1.5 * fs / current_f0);
@@ -147,7 +147,7 @@ void GetWindowedWaveform(const double *x, int x_length, int fs,
 // Caution:
 //   forward_fft is allocated in advance to speed up the processing.
 //-----------------------------------------------------------------------------
-void CheapTrickGeneralBody(const double *x, int x_length, int fs,
+static void CheapTrickGeneralBody(const double *x, int x_length, int fs,
     double current_f0, int fft_size, double temporal_position, double q1,
     const ForwardRealFFT *forward_real_fft,
     const InverseRealFFT *inverse_real_fft, double *spectral_envelope) {

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -26,7 +26,7 @@ namespace {
 //-----------------------------------------------------------------------------
 // SetParametersForLinearSmoothing() is used in LinearSmoothing()
 //-----------------------------------------------------------------------------
-void SetParametersForLinearSmoothing(int boundary, int fft_size, int fs,
+static void SetParametersForLinearSmoothing(int boundary, int fft_size, int fs,
     double width, const double *power_spectrum, double *mirroring_spectrum,
     double *mirroring_segment, double *frequency_axis) {
   for (int i = 0; i < boundary; ++i)

--- a/src/d4c.cpp
+++ b/src/d4c.cpp
@@ -18,7 +18,7 @@ namespace {
 //-----------------------------------------------------------------------------
 // SetParametersForGetWindowedWaveform()
 //-----------------------------------------------------------------------------
-void SetParametersForGetWindowedWaveform(int half_window_length, int x_length,
+static void SetParametersForGetWindowedWaveform(int half_window_length, int x_length,
     double temporal_position, int fs, double current_f0, int window_type,
     int *base_index, int *index, double *window) {
   for (int i = -half_window_length; i <= half_window_length; ++i)
@@ -48,7 +48,7 @@ void SetParametersForGetWindowedWaveform(int half_window_length, int x_length,
 // GetWindowedWaveform() windows the waveform by F0-adaptive window
 // In the variable window_type, 1: hanning, 2: blackman
 //-----------------------------------------------------------------------------
-void GetWindowedWaveform(const double *x, int x_length, int fs,
+static void GetWindowedWaveform(const double *x, int x_length, int fs,
     double current_f0, double temporal_position, int window_type,
     double window_length_ratio, double *waveform) {
   int half_window_length =
@@ -86,7 +86,7 @@ void GetWindowedWaveform(const double *x, int x_length, int fs,
 // GetCentroid() calculates the energy centroid (see the book, time-frequency
 // analysis written by L. Cohen).
 //-----------------------------------------------------------------------------
-void GetCentroid(const double *x, int x_length, int fs, double current_f0,
+static void GetCentroid(const double *x, int x_length, int fs, double current_f0,
     int fft_size, double temporal_position,
     const ForwardRealFFT *forward_real_fft, double *centroid) {
   for (int i = 0; i < fft_size; ++i) forward_real_fft->waveform[i] = 0.0;
@@ -121,7 +121,7 @@ void GetCentroid(const double *x, int x_length, int fs, double current_f0,
 // GetStaticCentroid() calculates the temporally static energy centroid.
 // Basic idea was proposed by H. Kawahara.
 //-----------------------------------------------------------------------------
-void GetStaticCentroid(const double *x, int x_length, int fs,
+static void GetStaticCentroid(const double *x, int x_length, int fs,
     double current_f0, int fft_size, double temporal_position,
     const ForwardRealFFT *forward_real_fft, double *static_centroid) {
   double *centroid1 = new double[fft_size / 2 + 1];
@@ -144,7 +144,7 @@ void GetStaticCentroid(const double *x, int x_length, int fs,
 // GetSmoothedPowerSpectrum() calculates the smoothed power spectrum.
 // The parameters used for smoothing are optimized in davance.
 //-----------------------------------------------------------------------------
-void GetSmoothedPowerSpectrum(const double *x, int x_length, int fs,
+static void GetSmoothedPowerSpectrum(const double *x, int x_length, int fs,
     double current_f0, int fft_size, double temporal_position,
     const ForwardRealFFT *forward_real_fft, double *smoothed_power_spectrum) {
   for (int i = 0; i < fft_size; ++i) forward_real_fft->waveform[i] = 0.0;
@@ -167,7 +167,7 @@ void GetSmoothedPowerSpectrum(const double *x, int x_length, int fs,
 // GetStaticGroupDelay() calculates the temporally static group delay.
 // This is the fundamental parameter in D4C.
 //-----------------------------------------------------------------------------
-void GetStaticGroupDelay(const double *static_centroid,
+static void GetStaticGroupDelay(const double *static_centroid,
     const double *smoothed_power_spectrum, int fs, double current_f0,
     int fft_size, double *static_group_delay) {
   for (int i = 0; i <= fft_size / 2; ++i)
@@ -189,7 +189,7 @@ void GetStaticGroupDelay(const double *static_centroid,
 // GetCoarseAperiodicity() calculates the aperiodicity in multiples of 3 kHz.
 // The upper limit is given based on the sampling frequency.
 //-----------------------------------------------------------------------------
-void GetCoarseAperiodicity(const double *static_group_delay, int fs,
+static void GetCoarseAperiodicity(const double *static_group_delay, int fs,
     double current_f0, int fft_size, int number_of_aperiodicities,
     const double *window, int window_length,
     const ForwardRealFFT *forward_real_fft, double *coarse_aperiodicity) {
@@ -228,7 +228,7 @@ void GetCoarseAperiodicity(const double *static_group_delay, int fs,
 // Caution:
 //   forward_fft is allocated in advance to speed up the processing.
 //-----------------------------------------------------------------------------
-void D4CGeneralBody(const double *x, int x_length, int fs, double current_f0,
+static void D4CGeneralBody(const double *x, int x_length, int fs, double current_f0,
     int fft_size, double temporal_position, int number_of_aperiodicities,
     const double *window, int window_length,
     const ForwardRealFFT *forward_real_fft, double *coarse_aperiodicity) {

--- a/src/dio.cpp
+++ b/src/dio.cpp
@@ -36,7 +36,7 @@ namespace {
 //-----------------------------------------------------------------------------
 // DesignLowCutFilter() calculates the coefficients the filter.
 //-----------------------------------------------------------------------------
-void DesignLowCutFilter(int N, int fft_size, double *low_cut_filter) {
+static void DesignLowCutFilter(int N, int fft_size, double *low_cut_filter) {
   for (int i = 1; i <= N; ++i)
     low_cut_filter[i - 1] = 0.5 - 0.5 * cos(i * 2.0 * world::kPi / (N + 1));
   for (int i = N; i < fft_size; ++i) low_cut_filter[i] = 0.0;
@@ -56,7 +56,7 @@ void DesignLowCutFilter(int N, int fft_size, double *low_cut_filter) {
 // This function carries out downsampling to speed up the estimation process
 // and calculates the spectrum of the downsampled signal.
 //-----------------------------------------------------------------------------
-void GetSpectrumForEstimation(const double *x, int x_length, int y_length,
+static void GetSpectrumForEstimation(const double *x, int x_length, int y_length,
     double actual_fs, int fft_size, int decimation_ratio,
     fft_complex *y_spectrum) {
   double *y = new double[fft_size];
@@ -108,7 +108,7 @@ void GetSpectrumForEstimation(const double *x, int x_length, int y_length,
 // GetBestF0Contour() calculates the best f0 contour based on stabilities of
 // all candidates. The F0 whose stability is minimum is selected.
 //-----------------------------------------------------------------------------
-void GetBestF0Contour(int f0_length, double **const f0_candidate_map,
+static void GetBestF0Contour(int f0_length, double **const f0_candidate_map,
     double **const f0_stability_map, int number_of_bands,
     double *best_f0_contour) {
   double tmp;
@@ -128,7 +128,7 @@ void GetBestF0Contour(int f0_length, double **const f0_candidate_map,
 // FixStep1() is the 1st step of the postprocessing.
 // This function eliminates the unnatural change of f0 based on allowed_range.
 //-----------------------------------------------------------------------------
-void FixStep1(const double *best_f0_contour, int f0_length,
+static void FixStep1(const double *best_f0_contour, int f0_length,
     int voice_range_minimum, double allowed_range, double *f0_step1) {
   double *f0_base = new double[f0_length];
   // Initialization
@@ -152,7 +152,7 @@ void FixStep1(const double *best_f0_contour, int f0_length,
 // FixStep2() is the 2nd step of the postprocessing.
 // This function eliminates the suspected f0 in the anlaut and auslaut.
 //-----------------------------------------------------------------------------
-void FixStep2(const double *f0_step1, int f0_length, int voice_range_minimum,
+static void FixStep2(const double *f0_step1, int f0_length, int voice_range_minimum,
     double *f0_step2) {
   for (int i = 0; i < f0_length; ++i) f0_step2[i] = f0_step1[i];
 
@@ -170,7 +170,7 @@ void FixStep2(const double *f0_step1, int f0_length, int voice_range_minimum,
 //-----------------------------------------------------------------------------
 // CountNumberOfVoicedSections() counts the number of voiced sections.
 //-----------------------------------------------------------------------------
-void CountNumberOfVoicedSections(const double *f0_step2, int f0_length,
+static void CountNumberOfVoicedSections(const double *f0_step2, int f0_length,
     int *positive_index, int *negative_index, int *positive_count,
     int *negative_count) {
   *positive_count = *negative_count = 0;
@@ -188,7 +188,7 @@ void CountNumberOfVoicedSections(const double *f0_step2, int f0_length,
 // SelectOneF0() corrects the f0[current_index] based on
 // f0[current_index + sign].
 //-----------------------------------------------------------------------------
-double SelectBestF0(double current_f0, double past_f0,
+static double SelectBestF0(double current_f0, double past_f0,
     double **const f0_candidates, int number_of_candidates, int target_index,
     double allowed_range) {
   double reference_f0 = (current_f0 * 3.0 - past_f0) / 2.0;
@@ -213,7 +213,7 @@ double SelectBestF0(double current_f0, double past_f0,
 // FixStep3() is the 3rd step of the postprocessing.
 // This function corrects the f0 candidates from backward to forward.
 //-----------------------------------------------------------------------------
-void FixStep3(const double *f0_step2, int f0_length,
+static void FixStep3(const double *f0_step2, int f0_length,
     double **const f0_candidates, int number_of_candidates,
     double allowed_range, const int *negative_index, int negative_count,
     double *f0_step3) {
@@ -235,7 +235,7 @@ void FixStep3(const double *f0_step2, int f0_length,
 // BackwardCorrection() is the 4th step of the postprocessing.
 // This function corrects the f0 candidates from forward to backward.
 //-----------------------------------------------------------------------------
-void FixStep4(const double *f0_step3, int f0_length,
+static void FixStep4(const double *f0_step3, int f0_length,
     double **const f0_candidates, int number_of_candidates,
     double allowed_range, const int *positive_index, int positive_count,
     double *f0_step4) {
@@ -257,7 +257,7 @@ void FixStep4(const double *f0_step3, int f0_length,
 // FixF0Contour() calculates the definitive f0 contour based on all f0
 // candidates. There are four steps.
 //-----------------------------------------------------------------------------
-void FixF0Contour(double frame_period, int number_of_candidates,
+static void FixF0Contour(double frame_period, int number_of_candidates,
     int fs, double **const f0_candidates, const double *best_f0_contour,
     int f0_length, double f0_floor, double allowed_range,
     double *fixed_f0_contour) {
@@ -294,7 +294,7 @@ void FixF0Contour(double frame_period, int number_of_candidates,
 // input signal and low-pass filter.
 // This function is only used in RawEventByDio()
 //-----------------------------------------------------------------------------
-void GetFilteredSignal(int half_average_length, int fft_size,
+static void GetFilteredSignal(int half_average_length, int fft_size,
     const fft_complex *y_spectrum, int y_length, double *filtered_signal) {
   double *low_pass_filter = new double[fft_size];
   // Nuttall window is used as a low-pass filter.
@@ -347,7 +347,7 @@ void GetFilteredSignal(int half_average_length, int fft_size,
 // CheckEvent() returns 1, provided that the input value is over 1.
 // This function is for RawEventByDio().
 //-----------------------------------------------------------------------------
-inline int CheckEvent(int x) {
+static inline int CheckEvent(int x) {
   return x > 0 ? 1 : 0;
 }
 
@@ -355,7 +355,7 @@ inline int CheckEvent(int x) {
 // ZeroCrossingEngine() calculates the zero crossing points from positive to
 // negative. Thanks to Custom.Maid http://custom-made.seesaa.net/ (2012/8/19)
 //-----------------------------------------------------------------------------
-int ZeroCrossingEngine(const double *filtered_signal, int y_length, double fs,
+static int ZeroCrossingEngine(const double *filtered_signal, int y_length, double fs,
     double *interval_locations, double *intervals) {
   int *negative_going_points = new int[y_length];
 
@@ -400,7 +400,7 @@ int ZeroCrossingEngine(const double *filtered_signal, int y_length, double fs,
 // (3) Peak, and (4) dip. (3) and (4) are calculated from the zero-crossings of
 // the differential of waveform.
 //-----------------------------------------------------------------------------
-void GetFourZeroCrossingIntervals(double *filtered_signal, int y_length,
+static void GetFourZeroCrossingIntervals(double *filtered_signal, int y_length,
     double actual_fs, ZeroCrossings *zero_crossings) {
   // x_length / 4 (old version) is fixed at 2013/07/14
   const int kMaximumNumber = y_length;
@@ -439,7 +439,7 @@ void GetFourZeroCrossingIntervals(double *filtered_signal, int y_length,
 // GetF0CandidatesSub() calculates the f0 candidates and deviations.
 // This is the sub-function of GetF0Candidates() and assumes the calculation.
 //-----------------------------------------------------------------------------
-void GetF0CandidatesSub(double **const interpolated_f0_set,
+static void GetF0CandidatesSub(double **const interpolated_f0_set,
     int time_axis_length, double f0_floor, double f0_ceil, double boundary_f0,
     double *f0_candidates, double *f0_deviations) {
   for (int i = 0; i < time_axis_length; ++i) {
@@ -469,7 +469,7 @@ void GetF0CandidatesSub(double **const interpolated_f0_set,
 // GetF0Candidates() calculates the F0 candidates based on the zero-crossings.
 // Calculation of F0 candidates is carried out in GetF0CandidatesSub().
 //-----------------------------------------------------------------------------
-void GetF0Candidates(const ZeroCrossings *zero_crossings, double boundary_f0,
+static void GetF0Candidates(const ZeroCrossings *zero_crossings, double boundary_f0,
     double f0_floor, double f0_ceil, const double *time_axis,
     int time_axis_length, double *f0_candidates, double *f0_deviations) {
   if (0 == CheckEvent(zero_crossings->number_of_negatives - 2) *
@@ -510,7 +510,7 @@ void GetF0Candidates(const ZeroCrossings *zero_crossings, double boundary_f0,
 //-----------------------------------------------------------------------------
 // DestroyZeroCrossings() frees the memory of array in the struct
 //-----------------------------------------------------------------------------
-void DestroyZeroCrossings(ZeroCrossings *zero_crossings) {
+static void DestroyZeroCrossings(ZeroCrossings *zero_crossings) {
   delete[] zero_crossings->negative_interval_locations;
   delete[] zero_crossings->positive_interval_locations;
   delete[] zero_crossings->peak_interval_locations;
@@ -524,7 +524,7 @@ void DestroyZeroCrossings(ZeroCrossings *zero_crossings) {
 //-----------------------------------------------------------------------------
 // RawEventByDio() calculates the zero-crossings.
 //-----------------------------------------------------------------------------
-void CalculateRawEvent(double boundary_f0, double fs,
+static void CalculateRawEvent(double boundary_f0, double fs,
     const fft_complex *y_spectrum, int y_length, int fft_size, double f0_floor,
     double f0_ceil, const double *time_axis, int time_axis_length,
     double *f0_deviations, double *f0_candidates) {
@@ -547,7 +547,7 @@ void CalculateRawEvent(double boundary_f0, double fs,
 // GetF0CandidateAndStabilityMap() calculates all f0 candidates and
 // their stabilities.
 //-----------------------------------------------------------------------------
-void GetF0CandidateAndStabilityMap(double *boundary_f0_list,
+static void GetF0CandidateAndStabilityMap(double *boundary_f0_list,
     int number_of_bands, double actual_fs, int y_length,
     double *time_axis, int f0_length, fft_complex *y_spectrum,
     int fft_size, double f0_floor, double f0_ceil,
@@ -576,7 +576,7 @@ void GetF0CandidateAndStabilityMap(double *boundary_f0_list,
 // DioGeneralBody() estimates the F0 based on Distributed Inline-filter
 // Operation.
 //-----------------------------------------------------------------------------
-void DioGeneralBody(double *x, int x_length, int fs, double frame_period,
+static void DioGeneralBody(double *x, int x_length, int fs, double frame_period,
     double f0_floor, double f0_ceil, double channels_in_octave, int speed,
     double allowed_range, double *time_axis, double *f0) {
   int number_of_bands = 1 + static_cast<int>(log(f0_ceil / f0_floor) /

--- a/src/fft.cpp
+++ b/src/fft.cpp
@@ -22,7 +22,7 @@ void cdft(int n, int isgn, double *a, int *ip, double *w);
 void rdft(int n, int isgn, double *a, int *ip, double *w);
 
 namespace {
-void BackwardFFT(fft_plan p) {
+static void BackwardFFT(fft_plan p) {
   if (p.c_out == NULL) {  // c2r
     p.input[0] = p.c_in[0][0];
     p.input[1] = p.c_in[p.n / 2][0];
@@ -45,7 +45,7 @@ void BackwardFFT(fft_plan p) {
   }
 }
 
-void ForwardFFT(fft_plan p) {
+static void ForwardFFT(fft_plan p) {
   if (p.c_in == NULL) {  // r2c
     for (int i = 0; i < p.n; ++i) p.input[i] = p.in[i];
     rdft(p.n, 1, p.input, p.ip, p.w);

--- a/src/matlabfunctions.cpp
+++ b/src/matlabfunctions.cpp
@@ -22,7 +22,7 @@ namespace {
 // FilterForDecimate() calculates the coefficients of low-pass filter and
 // carries out the filtering. This function is only used for decimate().
 //-----------------------------------------------------------------------------
-void FilterForDecimate(const double *x, int x_length, int r, double *y) {
+static void FilterForDecimate(const double *x, int x_length, int r, double *y) {
   double a[3], b[2];  // filter Coefficients
   switch (r) {
     case 11:  // fs : 44100 (default)

--- a/src/stonemask.cpp
+++ b/src/stonemask.cpp
@@ -21,7 +21,7 @@ namespace {
 // Since the result includes negative value and the value that exceeds the
 // length of the input signal, it must be modified appropriately.
 //-----------------------------------------------------------------------------
-void GetIndexRaw(double current_time, const double *base_time,
+static void GetIndexRaw(double current_time, const double *base_time,
     int base_time_length, int fs, int *index_raw) {
   for (int i = 0; i < base_time_length; ++i)
     index_raw[i] = matlab_round((current_time + base_time[i]) * fs);
@@ -30,7 +30,7 @@ void GetIndexRaw(double current_time, const double *base_time,
 //-----------------------------------------------------------------------------
 // GetMainWindow() generates the window function.
 //-----------------------------------------------------------------------------
-void GetMainWindow(double current_time, const int *index_raw,
+static void GetMainWindow(double current_time, const int *index_raw,
     int base_time_length, int fs, double window_length_in_time,
     double *main_window) {
   double tmp = 0.0;
@@ -46,7 +46,7 @@ void GetMainWindow(double current_time, const int *index_raw,
 // GetDiffWindow() generates the differentiated window.
 // Diff means differential.
 //-----------------------------------------------------------------------------
-void GetDiffWindow(const double *main_window, int base_time_length,
+static void GetDiffWindow(const double *main_window, int base_time_length,
     double *diff_window) {
   diff_window[0] = -main_window[1] / 2.0;
   for (int i = 1; i < base_time_length - 1; ++i)
@@ -58,7 +58,7 @@ void GetDiffWindow(const double *main_window, int base_time_length,
 // GetSpectra() calculates two spectra of the waveform windowed by windows
 // (main window and diff window).
 //-----------------------------------------------------------------------------
-void GetSpectra(const double *x, int x_length, int fft_size,
+static void GetSpectra(const double *x, int x_length, int fft_size,
     const int *index_raw, const double *main_window, const double *diff_window,
     int base_time_length, const ForwardRealFFT *forward_real_fft,
     fft_complex *main_spectrum, fft_complex *diff_spectrum) {
@@ -93,7 +93,7 @@ void GetSpectra(const double *x, int x_length, int fft_size,
 //-----------------------------------------------------------------------------
 // FixF0() fixed the F0 by instantaneous frequency.
 //-----------------------------------------------------------------------------
-double FixF0(const double *power_spectrum, const double *numerator_i,
+static double FixF0(const double *power_spectrum, const double *numerator_i,
     int fft_size, int fs, double f0_initial, int number_of_harmonics) {
   double *power_list = new double[number_of_harmonics];
   double *fixp_list = new double[number_of_harmonics];
@@ -120,7 +120,7 @@ double FixF0(const double *power_spectrum, const double *numerator_i,
 // Calculated value is tentative because it is fixed as needed.
 // Note: The sixth argument in FixF0() is not optimized.
 //-----------------------------------------------------------------------------
-double GetTentativeF0(const double *power_spectrum, const double *numerator_i,
+static double GetTentativeF0(const double *power_spectrum, const double *numerator_i,
     int fft_size, int fs, double f0_initial) {
   double tentative_f0 =
     FixF0(power_spectrum, numerator_i, fft_size, fs, f0_initial, 2);
@@ -135,7 +135,7 @@ double GetTentativeF0(const double *power_spectrum, const double *numerator_i,
 //-----------------------------------------------------------------------------
 // GetMeanF0() calculates the instantaneous frequency.
 //-----------------------------------------------------------------------------
-double GetMeanF0(const double *x, int x_length, int fs, double current_time,
+static double GetMeanF0(const double *x, int x_length, int fs, double current_time,
     double f0_initial, int fft_size, double window_length_in_time,
     const double *base_time, int base_time_length) {
   ForwardRealFFT forward_real_fft = {0};
@@ -182,7 +182,7 @@ double GetMeanF0(const double *x, int x_length, int fs, double current_time,
 // GetRefinedF0() fixes the F0 estimated by Dio(). This function uses
 // instantaneous frequency.
 //-----------------------------------------------------------------------------
-double GetRefinedF0(const double *x, int x_length, int fs, double current_time,
+static double GetRefinedF0(const double *x, int x_length, int fs, double current_time,
     double current_f0) {
   // A safeguard was added (2015/12/02).
   if (current_f0 <= 0.0 || current_f0 > fs / 12.0)

--- a/src/synthesis.cpp
+++ b/src/synthesis.cpp
@@ -15,7 +15,7 @@
 
 namespace {
 
-void GetNoiseSpectrum(int noise_size, int fft_size,
+static void GetNoiseSpectrum(int noise_size, int fft_size,
     const ForwardRealFFT *forward_real_fft) {
   double average = 0.0;
   for (int i = 0; i < noise_size; ++i) {
@@ -34,7 +34,7 @@ void GetNoiseSpectrum(int noise_size, int fft_size,
 //-----------------------------------------------------------------------------
 // GetAperiodicResponse() calculates an aperiodic response.
 //-----------------------------------------------------------------------------
-void GetAperiodicResponse(int noise_size, int fft_size,
+static void GetAperiodicResponse(int noise_size, int fft_size,
     const double *spectrum, const double *aperiodic_ratio, double current_vuv,
     const ForwardRealFFT *forward_real_fft,
     const InverseRealFFT *inverse_real_fft,
@@ -75,7 +75,7 @@ void GetAperiodicResponse(int noise_size, int fft_size,
 //-----------------------------------------------------------------------------
 // GetPeriodicResponse() calculates an aperiodic response.
 //-----------------------------------------------------------------------------
-void GetPeriodicResponse(int fft_size, const double *spectrum,
+static void GetPeriodicResponse(int fft_size, const double *spectrum,
     const double *aperiodic_ratio, double current_vuv,
     const InverseRealFFT *inverse_real_fft,
     const MinimumPhaseAnalysis *minimum_phase, double *periodic_response) {
@@ -100,7 +100,7 @@ void GetPeriodicResponse(int fft_size, const double *spectrum,
   fftshift(inverse_real_fft->waveform, fft_size, periodic_response);
 }
 
-void GetSpectralEnvelope(double current_time, double frame_period,
+static void GetSpectralEnvelope(double current_time, double frame_period,
     int f0_length, double **const spectrogram, int fft_size,
     double *spectral_envelope) {
   int current_frame_floor = MyMinInt(f0_length - 1,
@@ -120,7 +120,7 @@ void GetSpectralEnvelope(double current_time, double frame_period,
   }
 }
 
-void GetAperiodicRatio(double current_time, double frame_period,
+static void GetAperiodicRatio(double current_time, double frame_period,
     int f0_length, double **const aperiodicity, int fft_size,
     double *aperiodic_spectrum) {
   int current_frame_floor = MyMinInt(f0_length - 1,
@@ -144,7 +144,7 @@ void GetAperiodicRatio(double current_time, double frame_period,
 //-----------------------------------------------------------------------------
 // GetOneFrameSegment() calculates a periodic and aperiodic response at a time.
 //-----------------------------------------------------------------------------
-void GetOneFrameSegment(double current_vuv, int noise_size,
+static void GetOneFrameSegment(double current_vuv, int noise_size,
     double **const spectrogram, int fft_size, double **const aperiodicity,
     int f0_length, double frame_period, double current_time, int fs,
     const ForwardRealFFT *forward_real_fft,
@@ -181,7 +181,7 @@ void GetOneFrameSegment(double current_vuv, int noise_size,
   delete[] aperiodic_response;
 }
 
-void GetTemporalParametersForTimeBase(const double *f0, int f0_length, int fs,
+static void GetTemporalParametersForTimeBase(const double *f0, int f0_length, int fs,
     int y_length, double frame_period, double *time_axis,
     double *coarse_time_axis, double *coarse_f0, double *coarse_vuv) {
   for (int i = 0; i < y_length; ++i)
@@ -199,7 +199,7 @@ void GetTemporalParametersForTimeBase(const double *f0, int f0_length, int fs,
 }
 
 
-int GetPulseLocationsForTimeBase(const double *interpolated_f0,
+static int GetPulseLocationsForTimeBase(const double *interpolated_f0,
     const double *time_axis, int y_length, int fs, double *pulse_locations,
     int *pulse_locations_index) {
 
@@ -234,7 +234,7 @@ int GetPulseLocationsForTimeBase(const double *interpolated_f0,
   return number_of_pulses;
 }
 
-int GetTimeBase(const double *f0, int f0_length, int fs,
+static int GetTimeBase(const double *f0, int f0_length, int fs,
     double frame_period, int y_length, double *pulse_locations,
     int *pulse_locations_index, double *interpolated_vuv) {
   double *time_axis = new double[y_length];


### PR DESCRIPTION
This change is just to let me automatically convert the source base from C++ to C99 using only simple regexps.
Converting anonymous namespace to static linkage will require more complex parsing of the code.
