### PR TITLE
Convert explicitly Struct-WorldSynthesizer's member

### DIFF
--- a/src/synthesisrealtime.cpp
+++ b/src/synthesisrealtime.cpp
@@ -444,11 +444,11 @@ void InitializeSynthesizer(int fs, double frame_period, int fft_size,
   // Initilize internal parameters
   RefreshSynthesizer(synth);
 
-  synth->minimum_phase = {0};
+  synth->minimum_phase = (MinimumPhaseAnalysis){0};
   InitializeMinimumPhaseAnalysis(fft_size, &synth->minimum_phase);
-  synth->inverse_real_fft = {0};
+  synth->inverse_real_fft = (InverseRealFFT){0};
   InitializeInverseRealFFT(fft_size, &synth->inverse_real_fft);
-  synth->forward_real_fft = {0};
+  synth->forward_real_fft = (ForwardRealFFT){0};
   InitializeForwardRealFFT(fft_size, &synth->forward_real_fft);
 }
 

--- a/src/synthesisrealtime.cpp
+++ b/src/synthesisrealtime.cpp
@@ -444,11 +444,8 @@ void InitializeSynthesizer(int fs, double frame_period, int fft_size,
   // Initilize internal parameters
   RefreshSynthesizer(synth);
 
-  synth->minimum_phase = (MinimumPhaseAnalysis){0};
   InitializeMinimumPhaseAnalysis(fft_size, &synth->minimum_phase);
-  synth->inverse_real_fft = (InverseRealFFT){0};
   InitializeInverseRealFFT(fft_size, &synth->inverse_real_fft);
-  synth->forward_real_fft = (ForwardRealFFT){0};
   InitializeForwardRealFFT(fft_size, &synth->forward_real_fft);
 }
 


### PR DESCRIPTION
Apple LLVM version 7.3.0 (clang-703.0.29) g++
g++ -O1 -g -Wall -fPIC -Isrc -o "build/objs/synthesisrealtime.o" -c "src/synthesisrealtime.cpp"
src/synthesisrealtime.cpp:447:26: error: expected expression
  synth->minimum_phase = {0};
                         ^
src/synthesisrealtime.cpp:449:29: error: expected expression
  synth->inverse_real_fft = {0};
                            ^
src/synthesisrealtime.cpp:451:29: error: expected expression
  synth->forward_real_fft = {0};
                            ^
3 errors generated.
make: *** [build/objs/synthesisrealtime.o] Error 1

When set {0} as initialize value to structure in structure initialize, error occurred.
So use Explicit Conversion or delete this code.
ref. ) http://qiita.com/Ki4mTaria/items/b6ab0bcbe9c87d4dc071#配列構造体の中身初期化忘れ２
In test/ctest.c and test/test.cpp use WorldSynthesizer synthesizer = { 0 }; 
It appeared that we don't need to initialize synth->minimum_phase, [inverse | forward]_real_fft.
