### PR TITLE
Expose lower F0 limit for CheapTrick

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,12 @@ build/
 
 # Test
 *.wav
+
+# Visual Studio
+visualstudio/.vs/
+visualstudio/Debug/
+visualstudio/Release/
+visualstudio/win.VC.VC.opendb
+visualstudio/win.VC.db
+visualstudio/win/Debug/
+visualstudio/win/Release/

--- a/src/cheaptrick.cpp
+++ b/src/cheaptrick.cpp
@@ -178,11 +178,15 @@ int GetFFTSizeForCheapTrick(int fs, const CheapTrickOption *option) {
       static_cast<int>(log(3.0 * fs / option->f0_floor + 1) / world::kLog2)));
 }
 
+double GetF0FloorForCheapTrick(int fs, int fft_size) {
+  return 3.0 * fs / (fft_size - 3.0);
+}
+
 void CheapTrick(const double *x, int x_length, int fs,
     const double *temporal_positions, const double *f0, int f0_length,
     const CheapTrickOption *option, double **spectrogram) {
   int fft_size = option->fft_size;
-  double f0_floor = 3.0 * fs / (fft_size - 3.0);
+  double f0_floor = GetF0FloorForCheapTrick(fs, fft_size);
   double *spectral_envelope = new double[fft_size];
 
   ForwardRealFFT forward_real_fft = {0};

--- a/src/world/cheaptrick.h
+++ b/src/world/cheaptrick.h
@@ -53,15 +53,31 @@ void InitializeCheapTrickOption(int fs, CheapTrickOption *option);
 
 //-----------------------------------------------------------------------------
 // GetFFTSizeForCheapTrick() calculates the FFT size based on the sampling
-// frequency and the lower limit of f0 (It is defined in world.h).
+// frequency and the lower limit of f0 (kFloorF0 defined in constantnumbers.h).
 //
 // Input:
 //   fs : Sampling frequency
+//   option : Option struct containing the lower f0 limit
 //
 // Output:
 //   FFT size
 //-----------------------------------------------------------------------------
 int GetFFTSizeForCheapTrick(int fs, const CheapTrickOption *option);
+
+//-----------------------------------------------------------------------------
+// GetF0FloorForCheapTrick() calculates actual lower f0 limit for CheapTrick
+// based on the sampling frequency and FFT size used. Whenever f0 is below
+// this threshold the spectrum will be analyzed as if the frame is unvoiced
+// (using kDefaultF0 defined in constantnumbers.h).
+//
+// Input:
+//   fs : Sampling frequency
+//   fft_size : FFT size
+//
+// Output:
+//   Lower f0 limit (Hz)
+//-----------------------------------------------------------------------------
+double GetF0FloorForCheapTrick(int fs, int fft_size);
 
 WORLD_END_C_DECLS
 

--- a/visualstudio/win/win.vcxproj
+++ b/visualstudio/win/win.vcxproj
@@ -91,6 +91,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
+      <AdditionalOptions>-I $(SolutionDir)..\src -I $(SolutionDir)..\tools %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>


### PR DESCRIPTION
I generally use WORLD with an external F0 estimator and would like to know the actual lower F0 limit at which CheapTrick considers the frame unvoiced. This PR adds this functionality to the API.

I also fixed the release configuration of the Visual Studio project, and add some of the VS2015 intermediate files to .gitignore (possibly not all).