### PR TITLE
Delete unused assignments

### DIFF
--- a/src/synthesis.cpp
+++ b/src/synthesis.cpp
@@ -53,11 +53,6 @@ static void GetAperiodicResponse(int noise_size, int fft_size,
 
   for (int i = 0; i <= fft_size / 2; ++i) {
     inverse_real_fft->spectrum[i][0] =
-      minimum_phase->minimum_phase_spectrum[i][0];
-    inverse_real_fft->spectrum[i][1] =
-      minimum_phase->minimum_phase_spectrum[i][1];
-
-    inverse_real_fft->spectrum[i][0] =
       minimum_phase->minimum_phase_spectrum[i][0] *
       forward_real_fft->spectrum[i][0] -
       minimum_phase->minimum_phase_spectrum[i][1] *

--- a/src/synthesisrealtime.cpp
+++ b/src/synthesisrealtime.cpp
@@ -63,11 +63,6 @@ static void GetAperiodicResponse(int noise_size, int fft_size,
 
   for (int i = 0; i <= fft_size / 2; ++i) {
     inverse_real_fft->spectrum[i][0] =
-      minimum_phase->minimum_phase_spectrum[i][0];
-    inverse_real_fft->spectrum[i][1] =
-      minimum_phase->minimum_phase_spectrum[i][1];
-
-    inverse_real_fft->spectrum[i][0] =
       minimum_phase->minimum_phase_spectrum[i][0] *
       forward_real_fft->spectrum[i][0] -
       minimum_phase->minimum_phase_spectrum[i][1] *


### PR DESCRIPTION
The variables are replaced immediately after the first assignments.  Removing them seems have no affect to the synthesized waveform.