### PR TITLE
Fix memory leak in Harvest

### DIFF
--- a/src/harvest.cpp
+++ b/src/harvest.cpp
@@ -1106,6 +1106,7 @@ static void SmoothF0Contour(const double *f0, int f0_length,
 
   for (int i = 0; i < number_of_boundaries / 2; ++i)
     delete[] multi_channel_f0[i];
+  delete[] multi_channel_f0;
   delete[] f0_contour;
   delete[] boundary_list;
 }


### PR DESCRIPTION
Found by clang address sanitizer

```
$ build/test arctic_a0030.wav

File information
Sampling : 16000 Hz 16 Bit
Length 23601 [sample]
Length 1.475062 [sec]

Analysis
Harvest: 1696 [msec]
CheapTrick: 77 [msec]
D4C: 240 [msec]

Synthesis 1 (conventional algorithm)
    WORLD: 126 [msec]

    Synthesis 2 (All frames are added at the same time)
    WORLD: 126 [msec]

    Synthesis 3 (Ring buffer is efficiently used.)
    WORLD: 130 [msec]
    complete.

    =================================================================
    ==4695==ERROR: LeakSanitizer: detected memory leaks

    Direct leak of 8 byte(s) in 1 object(s) allocated from:
        #0 0x50cd40 in operator new[](unsigned long)
    /home/ryuichi/llvm/projects/compiler-rt/lib/asan/asan_new_delete.cc:84
        #1 0x55183b in (anonymous namespace)::SmoothF0Contour(double
                const*, int, double*)
        /home/ryuichi/sp/world-cmake/src/harvest.cpp:1094:31
            #2 0x550383 in (anonymous
                    namespace)::HarvestGeneralBody(double const*, int,
                        int, int, double, double, double, int, double*,
                        double*)
    /home/ryuichi/sp/world-cmake/src/harvest.cpp:1200:3
        #3 0x54f9b8 in Harvest
    /home/ryuichi/sp/world-cmake/src/harvest.cpp:1239:3
        #4 0x51531d in (anonymous
                namespace)::F0EstimationHarvest(double*, int,
                    WorldParameters*)
    /home/ryuichi/sp/world-cmake/test/test.cpp:155:3
        #5 0x514237 in main
    /home/ryuichi/sp/world-cmake/test/test.cpp:394:3
        #6 0x7f8ac5d8382f in __libc_start_main
    /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:291
```