### PR TITLE
Fix -Wunused-result warnings.

### DIFF
--- a/tools/audioio.cpp
+++ b/tools/audioio.cpp
@@ -29,41 +29,47 @@ static inline int MyMinInt(int x, int y) {
   return x < y ? x : y;
 }
 
+#define FREAD(ptr, size, nmemb, stream)            \
+  if (fread(ptr, size, nmemb, stream) != nmemb) {  \
+    printf("fread() failed.\n");                   \
+    return 0;                                      \
+}
+
 //-----------------------------------------------------------------------------
 // CheckHeader() checks the .wav header. This function can only support the
 // monaural wave file. This function is only used in waveread().
 //-----------------------------------------------------------------------------
 static int CheckHeader(FILE *fp) {
   char data_check[5];
-  fread(data_check, 1, 4, fp);  // "RIFF"
+  FREAD(data_check, 1, 4, fp);  // "RIFF"
   data_check[4] = '\0';
   if (0 != strcmp(data_check, "RIFF")) {
     printf("RIFF error.\n");
     return 0;
   }
   fseek(fp, 4, SEEK_CUR);
-  fread(data_check, 1, 4, fp);  // "WAVE"
+  FREAD(data_check, 1, 4, fp);  // "WAVE"
   if (0 != strcmp(data_check, "WAVE")) {
     printf("WAVE error.\n");
     return 0;
   }
-  fread(data_check, 1, 4, fp);  // "fmt "
+  FREAD(data_check, 1, 4, fp);  // "fmt "
   if (0 != strcmp(data_check, "fmt ")) {
     printf("fmt error.\n");
     return 0;
   }
-  fread(data_check, 1, 4, fp);  // 1 0 0 0
+  FREAD(data_check, 1, 4, fp);  // 1 0 0 0
   if (!(16 == data_check[0] && 0 == data_check[1] &&
       0 == data_check[2] && 0 == data_check[3])) {
     printf("fmt (2) error.\n");
     return 0;
   }
-  fread(data_check, 1, 2, fp);  // 1 0
+  FREAD(data_check, 1, 2, fp);  // 1 0
   if (!(1 == data_check[0] && 0 == data_check[1])) {
     printf("Format ID error.\n");
     return 0;
   }
-  fread(data_check, 1, 2, fp);  // 1 0
+  FREAD(data_check, 1, 2, fp);  // 1 0
   if (!(1 == data_check[0] && 0 == data_check[1])) {
     printf("This function cannot support stereo file\n");
     return 0;
@@ -72,25 +78,25 @@ static int CheckHeader(FILE *fp) {
 }
 
 //-----------------------------------------------------------------------------
-// GetParameters() extracts fp, nbit, wav_length from the .wav file
+// GetParameters() extracts fs, nbit, wav_length from the .wav file
 // This function is only used in wavread().
 //-----------------------------------------------------------------------------
 static int GetParameters(FILE *fp, int *fs, int *nbit, int *wav_length) {
   char data_check[5] = {0};
   data_check[4] = '\0';
   unsigned char for_int_number[4];
-  fread(for_int_number, 1, 4, fp);
+  FREAD(for_int_number, 1, 4, fp);
   *fs = 0;
   for (int i = 3; i >= 0; --i) *fs = *fs * 256 + for_int_number[i];
   // Quantization
   fseek(fp, 6, SEEK_CUR);
-  fread(for_int_number, 1, 2, fp);
+  FREAD(for_int_number, 1, 2, fp);
   *nbit = for_int_number[0];
 
   // Skip until "data" is found. 2011/03/28
   while (0 != fread(data_check, 1, 1, fp)) {
     if (data_check[0] == 'd') {
-      fread(&data_check[1], 1, 3, fp);
+      FREAD(&data_check[1], 1, 3, fp);
       if (0 != strcmp(data_check, "data"))
         fseek(fp, -3, SEEK_CUR);
       else
@@ -102,7 +108,7 @@ static int GetParameters(FILE *fp, int *fs, int *nbit, int *wav_length) {
     return 0;
   }
 
-  fread(for_int_number, 1, 4, fp);  // "data"
+  FREAD(for_int_number, 1, 4, fp);  // "data"
   *wav_length = 0;
   for (int i = 3; i >= 0; --i)
     *wav_length = *wav_length * 256 + for_int_number[i];
@@ -186,12 +192,20 @@ int GetAudioLength(const char *filename) {
 
   // Quantization
   fseek(fp, 10, SEEK_CUR);
-  fread(for_int_number, 1, 2, fp);
+  if (fread(for_int_number, 1, 2, fp) != 2) {
+    printf("fread() failed.\n");
+    fclose(fp);
+    return -1;
+  }
   int nbit = for_int_number[0];
 
   while (0 != fread(data_check, 1, 1, fp)) {
     if ('d' == data_check[0]) {
-      fread(&data_check[1], 1, 3, fp);
+      if (fread(&data_check[1], 1, 3, fp) != 3) {
+        printf("fread() failed.\n");
+        fclose(fp);
+        return -1;
+      }
       if (0 != strcmp(data_check, "data"))
         fseek(fp, -3, SEEK_CUR);
       else
@@ -203,7 +217,11 @@ int GetAudioLength(const char *filename) {
     return -1;
   }
 
-  fread(for_int_number, 1, 4, fp);  // "data"
+  if (fread(for_int_number, 1, 4, fp) != 4) {  // "data"
+    printf("fread() failed.\n");
+    fclose(fp);
+    return -1;
+  }
   fclose(fp);
 
   int wav_length = 0;
@@ -232,13 +250,18 @@ void wavread(const char* filename, int *fs, int *nbit, double *x) {
     return;
   }
 
-  int quantization_byte = *nbit / 8;
+  size_t quantization_byte = *nbit / 8;
   double zero_line = pow(2.0, *nbit - 1);
   double tmp, sign_bias;
   unsigned char for_int_number[4];
   for (int i = 0; i < x_length; ++i) {
     sign_bias = tmp = 0.0;
-    fread(for_int_number, 1, quantization_byte, fp);  // "data"
+    if (fread(for_int_number, 1, quantization_byte, fp) != quantization_byte) {
+      // "data"
+      printf("fread() failed.\n");
+      fclose(fp);
+      return;
+    }
     if (for_int_number[quantization_byte-1] >= 128) {
       sign_bias = pow(2.0, *nbit - 1);
       for_int_number[quantization_byte - 1] =


### PR DESCRIPTION
I noticed that the return value of fread() wasn't being checked everywhere. This could mean that problems reading a file might go unnoticed. I've added some basic comparisons of the return values.