### PR TITLE
Fix a bug in the random number generator.

### DIFF
--- a/src/matlabfunctions.cpp
+++ b/src/matlabfunctions.cpp
@@ -249,6 +249,7 @@ double randn(void) {
   x = y;
   y = z;
   z = w;
+  w = (w ^ (w >> 19)) ^ (t ^ (t >> 8));
 
   unsigned int tmp = 0;
   for (int i = 0; i < 12; ++i) {

--- a/src/matlabfunctions.cpp
+++ b/src/matlabfunctions.cpp
@@ -15,6 +15,7 @@
 #include "world/matlabfunctions.h"
 
 #include <math.h>
+#include <stdint.h>
 
 #include "world/constantnumbers.h"
 
@@ -240,18 +241,18 @@ void interp1Q(double x, double shift, const double *y, int x_length,
 }
 
 double randn(void) {
-  static unsigned int x = 123456789;
-  static unsigned int y = 362436069;
-  static unsigned int z = 521288629;
-  static unsigned int w = 88675123;
-  unsigned int t;
+  static uint32_t x = 123456789;
+  static uint32_t y = 362436069;
+  static uint32_t z = 521288629;
+  static uint32_t w = 88675123;
+  uint32_t t;
   t = x ^ (x << 11);
   x = y;
   y = z;
   z = w;
   w = (w ^ (w >> 19)) ^ (t ^ (t >> 8));
 
-  unsigned int tmp = 0;
+  uint32_t tmp = 0;
   for (int i = 0; i < 12; ++i) {
     t = x ^ (x << 11);
     x = y;


### PR DESCRIPTION
https://github.com/mmorise/World/blob/master/src/matlabfunctions.cpp#L242

`randn` function implements an iterated [xorshift](https://en.wikipedia.org/wiki/Xorshift) random number generator that generates an approximately normal-distributed random variable (RV) by summing 12 uniform RVs in [0, 2^32 / 16].

Due to an incomplete initial iteration, it was empirically found that the values for w at the 2nd and 4th iterations will be nearly identical, breaking the i.i.d. assumption. The output RV will have a variance of (10 + 4) / 12 = 1.1667. This can be verified by feeding the vocoder a Gaussian white noise and measuring the variance of the output.

![screenshot from 2018-02-23 15-18-06](https://user-images.githubusercontent.com/4531595/36619738-7b5e26ca-18b5-11e8-80fd-bc8c1f9cb36c.png)

![screenshot from 2018-02-23 16-22-31](https://user-images.githubusercontent.com/4531595/36619806-c75be49a-18b5-11e8-93f4-141da3cb9f27.png)

The bug has been fixed by putting back the initial iteration on w. In addition, all occurrences of `unsigned int` have been replaced by `uint32_t` for good portability.