### PR TITLE
CheapTrick does not reproduce the exact same numerical value for each run

### DIFF
--- a/src/cheaptrick.cpp
+++ b/src/cheaptrick.cpp
@@ -200,6 +200,9 @@ void CheapTrick(const double *x, int x_length, int fs,
     const double *temporal_positions, const double *f0, int f0_length,
     const CheapTrickOption *option, double **spectrogram) {
   int fft_size = option->fft_size;
+
+  randn_reseed();
+
   double f0_floor = GetF0FloorForCheapTrick(fs, fft_size);
   double *spectral_envelope = new double[fft_size];
 

--- a/src/matlabfunctions.cpp
+++ b/src/matlabfunctions.cpp
@@ -240,26 +240,33 @@ void interp1Q(double x, double shift, const double *y, int x_length,
   delete[] delta_y;
 }
 
-double randn(void) {
-  static uint32_t x = 123456789;
-  static uint32_t y = 362436069;
-  static uint32_t z = 521288629;
-  static uint32_t w = 88675123;
-  uint32_t t;
-  t = x ^ (x << 11);
-  x = y;
-  y = z;
-  z = w;
-  w = (w ^ (w >> 19)) ^ (t ^ (t >> 8));
+static unsigned int g_randn_x = 123456789;
+static unsigned int g_randn_y = 362436069;
+static unsigned int g_randn_z = 521288629;
+static unsigned int g_randn_w = 88675123;
 
-  uint32_t tmp = w >> 4;
-  for (int i = 0; i < 11; ++i) {
-    t = x ^ (x << 11);
-    x = y;
-    y = z;
-    z = w;
-    w = (w ^ (w >> 19)) ^ (t ^ (t >> 8));
-    tmp += w >> 4;
+void randn_reseed() {
+    g_randn_x = 123456789;
+    g_randn_y = 362436069;
+    g_randn_z = 521288629;
+    g_randn_w = 88675123;
+}
+
+double randn(void) {
+  unsigned int t;
+  t = g_randn_x ^ (g_randn_x << 11);
+  g_randn_x = g_randn_y;
+  g_randn_y = g_randn_z;
+  g_randn_z = g_randn_w;
+
+  unsigned int tmp = 0;
+  for (int i = 0; i < 12; ++i) {
+    t = g_randn_x ^ (g_randn_x << 11);
+    g_randn_x = g_randn_y;
+    g_randn_y = g_randn_z;
+    g_randn_z = g_randn_w;
+    g_randn_w = (g_randn_w ^ (g_randn_w >> 19)) ^ (t ^ (t >> 8));
+    tmp += g_randn_w >> 4;
   }
   return tmp / 268435456.0 - 6.0;
 }

--- a/src/world/matlabfunctions.h
+++ b/src/world/matlabfunctions.h
@@ -134,6 +134,11 @@ void interp1Q(double x, double shift, const double *y, int x_length,
 double randn(void);
 
 //-----------------------------------------------------------------------------
+// randn_reseed() force to seed the pseudorandom generator using initial values.
+//-----------------------------------------------------------------------------
+void randn_reseed(void);
+
+//-----------------------------------------------------------------------------
 // fast_fftfilt() carries out the convolution on the frequency domain.
 //
 // Input:


### PR DESCRIPTION
This commit reseed the pseudo-random number generator each time CheapTrick is called so that the numerical results are always exactly the same.
This repeatability property is necessary for unit testing, e.g.