### PR TITLE
fix decimate bug

### DIFF
--- a/src/matlabfunctions.cpp
+++ b/src/matlabfunctions.cpp
@@ -198,7 +198,7 @@ void decimate(const double *x, int x_length, int r, double *y) {
   for (int i = 0; i < 2 * kNFact + x_length; ++i)
     tmp1[i] = tmp2[2 * kNFact + x_length - i - 1];
 
-  int nout = (x_length-1) / r + 1;
+  int nout = (x_length - 1) / r + 1;
   int nbeg = r - r * nout + x_length;
 
   int count = 0;


### PR DESCRIPTION
Compare with the world vocoder matlab implementation, when x_length is divisible with r, as it always add one, it exports the latest sample from the head expanded buffer to y[0]. This produces different results compare with the matlab simulation and I think the matlab result be the idea of the author. 
Following lines can both solve the problem and I prefer the second one.
int nout = ceil(x_length / (float) r);
int nout = (x_length-1) / r + 1;