### PR TITLE
Output file name length in parameter io examples

### DIFF
--- a/examples/parameter_io/apanalysis.cpp
+++ b/examples/parameter_io/apanalysis.cpp
@@ -50,7 +50,7 @@ int SetOption(int argc, char **argv, int *fft_size, double *threshold,
     if (strcmp(argv[argc], "-f") == 0) *fft_size = atoi(argv[argc + 1]);
     if (strcmp(argv[argc], "-t") == 0) *threshold = atof(argv[argc + 1]);
     if (strcmp(argv[argc], "-o") == 0)
-      snprintf(filename, sizeof(argv[argc + 1]), argv[argc + 1]);
+      snprintf(filename, strlen(argv[argc + 1]) + 1, "%s", argv[argc + 1]);
     if (strcmp(argv[argc], "-c") == 0) *compression_flag = 1;
     if (strcmp(argv[argc], "-h") == 0) {
       usage(argv[0]);

--- a/examples/parameter_io/f0analysis.cpp
+++ b/examples/parameter_io/f0analysis.cpp
@@ -50,7 +50,7 @@ int SetOption(int argc, char **argv, double *f0_floor, double *f0_ceil,
     if (strcmp(argv[argc], "-c") == 0) *f0_ceil = atof(argv[argc + 1]);
     if (strcmp(argv[argc], "-s") == 0) *frame_period = atof(argv[argc + 1]);
     if (strcmp(argv[argc], "-o") == 0)
-      snprintf(filename, sizeof(argv[argc + 1]), argv[argc + 1]);
+      snprintf(filename, strlen(argv[argc + 1]) + 1, "%s", argv[argc + 1]);
     if (strcmp(argv[argc], "-t") == 0) *text_flag = 1;
     if (strcmp(argv[argc], "-h") == 0) {
       usage(argv[0]);

--- a/examples/parameter_io/readandsynthesis.cpp
+++ b/examples/parameter_io/readandsynthesis.cpp
@@ -34,7 +34,7 @@ void usage(char *argv) {
 int SetOption(int argc, char **argv, char *filename) {
   while (--argc) {
     if (strcmp(argv[argc], "-o") == 0)
-      snprintf(filename, sizeof(argv[argc + 1]), argv[argc + 1]);
+      snprintf(filename, strlen(argv[argc + 1]) + 1, "%s", argv[argc + 1]);
     if (strcmp(argv[argc], "-h") == 0) {
       usage(argv[0]);
       return 0;

--- a/examples/parameter_io/spanalysis.cpp
+++ b/examples/parameter_io/spanalysis.cpp
@@ -54,7 +54,7 @@ int SetOption(int argc, char **argv, int *fft_size, double *q1,
     if (strcmp(argv[argc], "-d") == 0)
       *number_of_dimensions = atof(argv[argc + 1]);
     if (strcmp(argv[argc], "-o") == 0)
-      snprintf(filename, sizeof(argv[argc + 1]), argv[argc + 1]);
+      snprintf(filename, strlen(argv[argc + 1]) + 1, "%s", argv[argc + 1]);
     if (strcmp(argv[argc], "-h") == 0) {
       usage(argv[0]);
       return 0;


### PR DESCRIPTION
The length of the output file names were not correctly determined with sizeof, in this pull request these have been fixed.