### PR TITLE
Added isnan() check for tentative_f0 in GetTentativeF0

### DIFF
--- a/src/stonemask.cpp
+++ b/src/stonemask.cpp
@@ -125,7 +125,7 @@ static double GetTentativeF0(const double *power_spectrum,
     FixF0(power_spectrum, numerator_i, fft_size, fs, initial_f0, 2);
 
   // If the fixed value is too large, the result will be rejected.
-  if (tentative_f0 <= 0.0 || tentative_f0 > initial_f0 * 2) return 0.0;
+  if (tentative_f0 <= 0.0 || tentative_f0 > initial_f0 * 2 || isnan(tentative_f0)) return 0.0;
 
   return FixF0(power_spectrum, numerator_i, fft_size, fs, tentative_f0, 6);
 }


### PR DESCRIPTION
Thus rejecting nan/-nan tentative_f0 values. Got these on large (50s) WAVs of
synthesized speech.