### PR TITLE
synthesisrealtime_cppについて

### DIFF
--- a/src/synthesisrealtime.cpp
+++ b/src/synthesisrealtime.cpp
@@ -117,7 +117,7 @@ static int SeekSynthesizer(double current_location, WorldSynthesizer *synth) {
 
 static void SearchPointer(int frame,  WorldSynthesizer *synth, int flag,
     double **front, double **next) {
-  int pointer = synth->current_pointer2 % synth->number_of_pointers;
+  int pointer = synth->current_pointer % synth->number_of_pointers;
   int index = -1;
   for (int i = 0; i < synth->f0_length[pointer]; ++i)
     if (synth->f0_origin[pointer] + i == frame) {


### PR DESCRIPTION
初めまして。
標記の件について、気になる点があったためプルリクエストを送らせていただきました。
synthesisrealtime_cpp内、SearchPointer() でsynth->current_pointer2が使用されていますが、current_pointer2 はリングバッファ内において ClearRingBuffer()によってデータが破棄された位置を指す変数であり、synth->current_pointer を使用するべきなのではないかと思い書き換えてみました。
書き換えた状態でも私が試した限りでは問題なく動作しました。
ご確認をお願いします。