### PR TITLE
Resolve build errors on MinGW

### DIFF
--- a/examples/analysis_synthesis/analysis.cpp
+++ b/examples/analysis_synthesis/analysis.cpp
@@ -24,7 +24,7 @@
 #pragma comment(lib, "winmm.lib")
 #pragma warning(disable : 4996)
 #endif
-#if (defined (__linux__) || defined(__CYGWIN__) || defined(__APPLE__))
+#if (defined (__linux__) || defined(__CYGWIN__) || defined(__MINGW32__) || defined(__APPLE__))
 #include <stdint.h>
 #include <sys/time.h>
 #endif
@@ -41,7 +41,7 @@
 #include "world/cheaptrick.h"
 #include "world/stonemask.h"
 
-#if (defined (__linux__) || defined(__CYGWIN__) || defined(__APPLE__))
+#if (defined (__linux__) || defined(__CYGWIN__) || defined(__MINGW32__) || defined(__APPLE__))
 // Linux porting section: implement timeGetTime() by gettimeofday(),
 #ifndef DWORD
 #define DWORD uint32_t

--- a/examples/analysis_synthesis/synthesis.cpp
+++ b/examples/analysis_synthesis/synthesis.cpp
@@ -24,7 +24,7 @@
 #pragma comment(lib, "winmm.lib")
 #pragma warning(disable : 4996)
 #endif
-#if (defined (__linux__) || defined(__CYGWIN__) || defined(__APPLE__))
+#if (defined (__linux__) || defined(__CYGWIN__) || defined(__MINGW32__) || defined(__APPLE__))
 #include <stdint.h>
 #include <sys/time.h>
 #endif
@@ -43,7 +43,7 @@
 #include "world/synthesis.h"
 #include "world/synthesisrealtime.h"
 
-#if (defined (__linux__) || defined(__CYGWIN__) || defined(__APPLE__))
+#if (defined (__linux__) || defined(__CYGWIN__) || defined(__MINGW32__) || defined(__APPLE__))
 // Linux porting section: implement timeGetTime() by gettimeofday(),
 #ifndef DWORD
 #define DWORD uint32_t

--- a/makefile
+++ b/makefile
@@ -9,6 +9,11 @@ ARFLAGS = -rv
 OUT_DIR = ./build
 OBJS = $(OUT_DIR)/objs/world/cheaptrick.o $(OUT_DIR)/objs/world/common.o $(OUT_DIR)/objs/world/d4c.o $(OUT_DIR)/objs/world/dio.o $(OUT_DIR)/objs/world/fft.o $(OUT_DIR)/objs/world/harvest.o $(OUT_DIR)/objs/world/matlabfunctions.o $(OUT_DIR)/objs/world/stonemask.o $(OUT_DIR)/objs/world/synthesis.o $(OUT_DIR)/objs/world/synthesisrealtime.o
 LIBS =
+MKDIR = mkdir -p $(1)
+ifeq ($(shell echo "check_quotes"),"check_quotes")
+	# Windows
+	MKDIR = mkdir $(subst /,\,$(1)) > nul 2>&1 || (exit 0)
+endif
 
 all: default test
 
@@ -53,19 +58,19 @@ $(OUT_DIR)/objs/world/synthesisrealtime.o : src/world/synthesisrealtime.h src/wo
 ### Global rules
 ###############################################################################################################
 $(OUT_DIR)/objs/test/%.o : test/%.c
-	mkdir -p $(OUT_DIR)/objs/test
+	$(call MKDIR,$(OUT_DIR)/objs/test)
 	$(C99) $(CFLAGS) -Isrc -Itools -o "$@" -c "$<"
 
 $(OUT_DIR)/objs/test/%.o : test/%.cpp
-	mkdir -p $(OUT_DIR)/objs/test
+	$(call MKDIR,$(OUT_DIR)/objs/test)
 	$(CXX) $(CXXFLAGS) -Isrc -Itools -o "$@" -c "$<"
 
 $(OUT_DIR)/objs/tools/%.o : tools/%.cpp
-	mkdir -p $(OUT_DIR)/objs/tools
+	$(call MKDIR,$(OUT_DIR)/objs/tools)
 	$(CXX) $(CXXFLAGS) -Isrc -o "$@" -c "$<"
 
 $(OUT_DIR)/objs/world/%.o : src/%.cpp
-	mkdir -p $(OUT_DIR)/objs/world
+	$(call MKDIR,$(OUT_DIR)/objs/world)
 	$(CXX) $(CXXFLAGS) -Isrc -o "$@" -c "$<"
 
 clean:

--- a/test/ctest.c
+++ b/test/ctest.c
@@ -26,7 +26,7 @@
 #pragma comment(lib, "winmm.lib")
 #pragma warning(disable : 4996)
 #endif
-#if (defined (__linux__) || defined(__CYGWIN__) || defined(__APPLE__))
+#if (defined (__linux__) || defined(__CYGWIN__) || defined(__MINGW32__) || defined(__APPLE__))
 #include <stdint.h>
 #include <sys/time.h>
 #endif
@@ -44,7 +44,7 @@
 #include "world/synthesis.h"
 #include "world/synthesisrealtime.h"
 
-#if (defined (__linux__) || defined(__CYGWIN__) || defined(__APPLE__))
+#if (defined (__linux__) || defined(__CYGWIN__) || defined(__MINGW32__) || defined(__APPLE__))
 // Linux porting section: implement timeGetTime() by gettimeofday(),
 #ifndef DWORD
 #define DWORD uint32_t

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -26,7 +26,7 @@
 #pragma comment(lib, "winmm.lib")
 #pragma warning(disable : 4996)
 #endif
-#if (defined (__linux__) || defined(__CYGWIN__) || defined(__APPLE__))
+#if (defined (__linux__) || defined(__CYGWIN__) || defined(__MINGW32__) || defined(__APPLE__))
 #include <stdint.h>
 #include <sys/time.h>
 #endif
@@ -46,7 +46,7 @@
 #include "world/synthesis.h"
 #include "world/synthesisrealtime.h"
 
-#if (defined (__linux__) || defined(__CYGWIN__) || defined(__APPLE__))
+#if (defined (__linux__) || defined(__CYGWIN__) || defined(__MINGW32__) || defined(__APPLE__))
 // Linux porting section: implement timeGetTime() by gettimeofday(),
 #ifndef DWORD
 #define DWORD uint32_t


### PR DESCRIPTION
Made `mkdir` in makefile work on Windows.

Also, solves that gcc reports build errors about undeclared symbols (`DWORD` `timeGetTime` etc) during compiling tests.

My environment: MinGW installed by Chocolatey on Windows 10 x64