### PR TITLE
Harvest: two memory fixes that may have caused undefined behavior or segfaults

### DIFF
--- a/src/harvest.cpp
+++ b/src/harvest.cpp
@@ -709,13 +709,10 @@ static void SearchF0Base(const double * const *f0_candidates,
 //-----------------------------------------------------------------------------
 static void FixStep1(const double *f0_base, int f0_length,
     double allowed_range, double *f0_step1) {
-  f0_step1[0] = f0_step1[1] = 0.0;
+  for (int i = 0; i < f0_length; ++i) f0_step1[i] = 0.0;
   double reference_f0;
   for (int i = 2; i < f0_length; ++i) {
-    if (f0_base[i] == 0.0) {
-      f0_step1[i] = 0.0;
-      continue;
-    }
+    if (f0_base[i] == 0.0) continue;
     reference_f0 = f0_base[i - 1] * 2 - f0_base[i - 2];
     f0_step1[i] =
       fabs((f0_base[i] - reference_f0) / reference_f0) > allowed_range &&

--- a/src/harvest.cpp
+++ b/src/harvest.cpp
@@ -674,7 +674,7 @@ static void RemoveUnreliableCandidates(int f0_length, int number_of_candidates,
   double **tmp_f0_candidates = new double *[f0_length];
   for (int i = 0; i < f0_length; ++i)
     tmp_f0_candidates[i] = new double[number_of_candidates];
-  for (int i = 1; i < f0_length - 1; ++i)
+  for (int i = 0; i < f0_length; ++i)
     for (int j = 0; j < number_of_candidates; ++j)
       tmp_f0_candidates[i][j] = f0_candidates[i][j];
 

--- a/src/harvest.cpp
+++ b/src/harvest.cpp
@@ -712,7 +712,10 @@ static void FixStep1(const double *f0_base, int f0_length,
   f0_step1[0] = f0_step1[1] = 0.0;
   double reference_f0;
   for (int i = 2; i < f0_length; ++i) {
-    if (f0_base[i] == 0.0) continue;
+    if (f0_base[i] == 0.0) {
+      f0_step1[i] = 0.0;
+      continue;
+    }
     reference_f0 = f0_base[i - 1] * 2 - f0_base[i - 2];
     f0_step1[i] =
       fabs((f0_base[i] - reference_f0) / reference_f0) > allowed_range &&


### PR DESCRIPTION
This will fix potential undefined behavior (negative F0 or higher F0 over f0_ceil, those are what I see in fact!) and segfault issues when we use Harvest. Please see the individual commit message for details.

For reference, here are the analysis results with clang memory sanitizer (https://clang.llvm.org/docs/MemorySanitizer.html):


Without https://github.com/mmorise/World/commit/66e5dcdfcd368f21429d815ad6bf9b14aa9d46a8:
```
$ ./test ~/sp/nnsvs/egs/nit-song070/00-svs-world/data/acoustic/wav/nitech_jp_song070_f001_012.wav
File information
Sampling : 48000 Hz 16 Bit
Length 4262397 [sample]
Length 88.799937 [sec]

==7083==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x53e1a8 in (anonymous namespace)::GetBoundaryList(double const*, int, int*) /home/ryuichi/sp/world-cmake/src/harvest.cpp:739:9
    #1 0x53b83f in (anonymous namespace)::FixStep2(double const*, int, int, double*) /home/ryuichi/sp/world-cmake/src/harvest.cpp:756:5
    #2 0x525d4b in (anonymous namespace)::FixF0Contour(double const* const*, double const* const*, int, int, double*) /home/ryuichi/sp/world-cmake/src/harvest.cpp:1040:3
    #3 0x521f1a in (anonymous namespace)::HarvestGeneralBody(double const*, int, int, int, double, double, double, int, double*, double*) /home/ryuichi/sp/world-cmake/src/harvest.cpp:1204:3
    #4 0x51fc5d in Harvest /home/ryuichi/sp/world-cmake/src/harvest.cpp:1245:3
    #5 0x4aa9a5 in (anonymous namespace)::F0EstimationHarvest(double*, int, WorldParameters*) /home/ryuichi/sp/world-cmake/test/test.cpp:157:3
    #6 0x4a9108 in main /home/ryuichi/sp/world-cmake/test/test.cpp:398:3
    #7 0x7fd2acd8f82f in __libc_start_main /build/glibc-LK5gWL/glibc-2.23/csu/../csu/libc-start.c:291
    #8 0x41c1a8 in _start (/home/ryuichi/Dropbox/sp/world-cmake/build/test+0x41c1a8)

SUMMARY: MemorySanitizer: use-of-uninitialized-value /home/ryuichi/sp/world-cmake/src/harvest.cpp:739:9 in (anonymous namespace)::GetBoundaryList(double const*, int, int*)
```

Without https://github.com/mmorise/World/commit/33159af1e3e7d7c5b626fb34a7d675c74193a624:
```
$ ./test ~/sp/nnsvs/egs/nit-song070/00-svs-world/data/acoustic/wav/nitech_jp_song070_f001_012.wav
File information
Sampling : 48000 Hz 16 Bit
Length 4262397 [sample]
Length 88.799937 [sec]


Analysis
==8281==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x53a180 in (anonymous namespace)::SelectBestF0(double, double const*, int, double, double*) /home/ryuichi/sp/world-cmake/src/harvest.cpp:644:9
    #1 0x5398f9 in (anonymous namespace)::RemoveUnreliableCandidatesSub(int, int, double const* const*, int, double**, double**) /home/ryuichi/sp/world-cmake/src/harvest.cpp:659:3
    #2 0x52552a in (anonymous namespace)::RemoveUnreliableCandidates(int, int, double**, double**) /home/ryuichi/sp/world-cmake/src/harvest.cpp:683:7
    #3 0x521d84 in (anonymous namespace)::HarvestGeneralBody(double const*, int, int, int, double, double, double, int, double*, double*) /home/ryuichi/sp/world-cmake/src/harvest.cpp:1200:3
    #4 0x51fc5d in Harvest /home/ryuichi/sp/world-cmake/src/harvest.cpp:1245:3
    #5 0x4aa9a5 in (anonymous namespace)::F0EstimationHarvest(double*, int, WorldParameters*) /home/ryuichi/sp/world-cmake/test/test.cpp:157:3
    #6 0x4a9108 in main /home/ryuichi/sp/world-cmake/test/test.cpp:398:3
    #7 0x7fe5d070782f in __libc_start_main /build/glibc-LK5gWL/glibc-2.23/csu/../csu/libc-start.c:291
    #8 0x41c1a8 in _start (/home/ryuichi/Dropbox/sp/world-cmake/build/test+0x41c1a8)

SUMMARY: MemorySanitizer: use-of-uninitialized-value /home/ryuichi/sp/world-cmake/src/harvest.cpp:644:9 in (anonymous namespace)::SelectBestF0(double, double const*, int, double, double*)
```

Ref https://github.com/r9y9/nnsvs/issues/7.

With these two fixes, no issues are found with clang address/memory sanitizers, so there should be no memory/address issues.