### PR TITLE
Added cmake file to make building on multiple OSes and IDEs easier

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 2.8)
+
+set(PROJECT_NAME "WORLD")
+
+project(${PROJECT_NAME})
+
+FILE(GLOB SRCS "src/*.cpp" "src/*.c")
+
+add_library(${PROJECT_NAME} SHARED ${SRCS})
+
+target_include_directories(${PROJECT_NAME} PUBLIC "src")


### PR DESCRIPTION
Since the project only had Makefiles and visual studio solutions, I felt like a CMakeLists would be useful as they are a unified way to build C/C++ programs on any OS and any IDE. So I made one, I might also make some for the example projects but at the moment I only made one for WORLD itself. It at the moment builds WORLD as a shared library.