### PR TITLE
Updated the cmake to add the headers to project files + install target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,10 @@ project(${PROJECT_NAME})
 
 FILE(GLOB SRCS "src/*.cpp" "src/*.c")
 
-add_library(${PROJECT_NAME} SHARED ${SRCS})
+FILE(GLOB HEADERS "src/world/*.h" "src/world/*.hpp")
+
+add_library(${PROJECT_NAME} SHARED ${SRCS} ${HEADERS})
 
 target_include_directories(${PROJECT_NAME} PUBLIC "src")
+
+install(TARGETS ${PROJECT_NAME})


### PR DESCRIPTION
I've updated the cmake to add the install target and to add the headers to project files to easily edit them
technically I think the visual studio project files and the makefiles aren't required anymore as the cmake can auto-generate them.

also I think that now WORLD could be submitted to the ubuntu and other distributions package managers as libWORLD if it isn't already, it would include its headers and the libWORLD.so.
it could also be submitted to BREW to be available on the OS X package manager as well as libWORLD.dylib