### PR TITLE
fix CMake Deprecation Warning and more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,83 @@ visualstudio/win.VC.VC.opendb
 visualstudio/win.VC.db
 visualstudio/win/Debug/
 visualstudio/win/Release/
+
+# IntelliJ project files
+.idea
+*.iml
+out
+gen
+
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,34 @@
-cmake_minimum_required(VERSION 2.8)
+#
+# CMake build system design considerations:
+# - Include directories:
+#   + Do not define include directories globally using the include_directories
+#     command but rather at the target level using the
+#     target_include_directories command. That way, it is easier to guarantee
+#     that targets are built using the proper list of include directories.
+#   + Use the PUBLIC and PRIVATE keywords to specify the scope of include
+#     directories. That way, a target linking to a library (using the
+#     target_link_librairies command) inherits from the library PUBLIC include
+#     directories and not from the PRIVATE ones.
+#
+# CMake options for build WORLD
+# - STATIC_LIB: For build the static library, default off
+#
 
-set(PROJECT_NAME "WORLD")
+cmake_minimum_required(VERSION 2.8.12)
+project(WORLD CXX)
 
-project(${PROJECT_NAME})
+# options
+option(STATIC_LIB "Build as static library" OFF)
 
-FILE(GLOB SRCS "src/*.cpp" "src/*.c")
+file(GLOB SRCS "src/*.cpp" "src/*.c")
+file(GLOB HEADERS "src/world/*.h")
 
-FILE(GLOB HEADERS "src/world/*.h" "src/world/*.hpp")
 
-add_library(${PROJECT_NAME} SHARED ${SRCS} ${HEADERS})
+if (STATIC_LIB)
+    add_library(${PROJECT_NAME} ${SRCS} ${HEADERS})
+else (STATIC_LIB)
+    add_library(${PROJECT_NAME} SHARED ${SRCS} ${HEADERS})
+endif (STATIC_LIB)
 
 target_include_directories(${PROJECT_NAME} PUBLIC "src")
 


### PR DESCRIPTION
- Add gitignore for jetbrains IDE.
- Fix CMake Deprecation Warning

> CMake Deprecation Warning at CMakeLists.txt:17 (cmake_minimum_required):
> Compatibility with CMake < 2.8.12 will be removed from a future version of
> CMake.
>  Update the VERSION argument <min> value or use a ...<max> suffix to tell
>  CMake that the project does not need compatibility with older versions.
- Add option to build static library