### PR TITLE
Add new features in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@
 # - STATIC_LIB: For build the static library, default off
 #
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.0)
 project(WORLD CXX)
 
 # options

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,26 +10,94 @@
 #     target_link_librairies command) inherits from the library PUBLIC include
 #     directories and not from the PRIVATE ones.
 #
-# CMake options for build WORLD
-# - STATIC_LIB: For build the static library, default off
 #
 
 cmake_minimum_required(VERSION 3.0)
-project(WORLD CXX)
 
-# options
-option(STATIC_LIB "Build as static library" OFF)
+# use git version as library version
+find_package(Git QUIET)
+if (Git_FOUND AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
+    execute_process(
+            COMMAND ${GIT_EXECUTABLE} rev-list --count HEAD
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+            OUTPUT_VARIABLE git_version
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+else ()
+    set(git_version 0)
+endif ()
 
-file(GLOB SRCS "src/*.cpp" "src/*.c")
-file(GLOB HEADERS "src/world/*.h")
+project(WORLD LANGUAGES CXX VERSION 1.0.${git_version})
 
+add_library(world STATIC
+        src/world/cheaptrick.h
+        src/world/codec.h
+        src/world/common.h
+        src/world/constantnumbers.h
+        src/world/d4c.h
+        src/world/dio.h
+        src/world/fft.h
+        src/world/harvest.h
+        src/world/macrodefinitions.h
+        src/world/matlabfunctions.h
+        src/world/stonemask.h
+        src/world/synthesis.h
+        src/world/synthesisrealtime.h
+        src/cheaptrick.cpp
+        src/codec.cpp
+        src/common.cpp
+        src/d4c.cpp
+        src/dio.cpp
+        src/fft.cpp
+        src/harvest.cpp
+        src/matlabfunctions.cpp
+        src/stonemask.cpp
+        src/synthesis.cpp
+        src/synthesisrealtime.cpp
+        )
 
-if (STATIC_LIB)
-    add_library(${PROJECT_NAME} ${SRCS} ${HEADERS})
-else (STATIC_LIB)
-    add_library(${PROJECT_NAME} SHARED ${SRCS} ${HEADERS})
-endif (STATIC_LIB)
+add_library(world_tool STATIC
+        tools/audioio.h
+        tools/parameterio.h
+        tools/audioio.cpp
+        tools/parameterio.cpp
+        )
 
-target_include_directories(${PROJECT_NAME} PUBLIC "src")
+add_library(world::core ALIAS world)
+add_library(world::tool ALIAS world_tool)
+target_link_libraries(world_tool PUBLIC world)
 
-install(TARGETS ${PROJECT_NAME})
+foreach (lib world world_tool)
+    target_include_directories(${lib} PUBLIC $<INSTALL_INTERFACE:include>
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> PRIVATE src)
+endforeach ()
+
+include(GNUInstallDirs)
+install(TARGETS world world_tool
+        EXPORT world-export
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        )
+install(DIRECTORY src/world DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(world-config.cmake.in
+        ${CMAKE_CURRENT_BINARY_DIR}/world-config.cmake
+        INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/world/cmake
+        PATH_VARS CMAKE_INSTALL_INCLUDEDIR
+        )
+write_basic_package_version_file(
+        world-config-version.cmake
+        VERSION ${PACKAGE_VERSION}
+        COMPATIBILITY AnyNewerVersion
+)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/world-config.cmake
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/world
+        )
+install(EXPORT world-export
+        FILE world-config-version.cmake
+        NAMESPACE world::
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/world
+        )
+export(TARGETS world world_tool NAMESPACE world::
+        FILE ${PROJECT_BINARY_DIR}/world-targets.cmake)

--- a/world-config.cmake.in
+++ b/world-config.cmake.in
@@ -1,0 +1,1 @@
+@PACKAGE_INIT@


### PR DESCRIPTION
- fix CMake Warning in macOS.
   ```
    CMake Warning (dev):
      Policy CMP0042 is not set: MACOSX_RPATH is enabled by default.  Run "cmake
      --help-policy CMP0042" for policy details.  Use the cmake_policy command to
      set the policy and suppress this warning.

      MACOSX_RPATH is not specified for the following targets:

       WORLD
   ```
- delete compile to shared library due to makefile not provide.
- update install script.
- add support for cmake submodule and find feature.