### PR TITLE
fix: support `add_subdirectory`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 #     target_link_librairies command) inherits from the library PUBLIC include
 #     directories and not from the PRIVATE ones.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.0...3.30)
 
 # Build Options
 option(WORLD_BUILD_TESTS "Set to ON to build tests" OFF)
@@ -64,14 +64,15 @@ add_library(world_tool STATIC
         tools/parameterio.cpp
         )
 
+target_include_directories(world PUBLIC $<INSTALL_INTERFACE:include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>)
+target_include_directories(world_tool PUBLIC $<INSTALL_INTERFACE:include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/tools>)
+
 add_library(world::core ALIAS world)
 add_library(world::tool ALIAS world_tool)
 
-target_link_libraries(world_tool PUBLIC world)
-
 foreach (lib world world_tool)
-    target_include_directories(${lib} PUBLIC $<INSTALL_INTERFACE:include>
-            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> PRIVATE src)
     set_target_properties(${lib}
             PROPERTIES
             ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
@@ -115,10 +116,6 @@ if (WORLD_BUILD_TESTS)
     target_link_libraries(tests
             PRIVATE world
             PRIVATE world_tool
-            )
-    target_include_directories(tests
-            PRIVATE src
-            PRIVATE tools
             )
 endif ()
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,7 +1,5 @@
 set(EXAMPLES_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
-include_directories(../tools ../src)
-
 function(example name)
     add_executable(${DIRECTORY_LIB}_${name} ${name}.cpp)
     target_link_libraries(${DIRECTORY_LIB}_${name} PUBLIC world world_tool)


### PR DESCRIPTION
If you add World using `add_subdirectory`, the include path for World will not be added when you use `target_link_libraries`.

And change `cmake_minimum_required` to fix the CMake Deprecation Warning.