### PR TITLE
feat: randn without the global variables.

### DIFF
--- a/src/matlabfunctions.cpp
+++ b/src/matlabfunctions.cpp
@@ -234,38 +234,31 @@ void interp1Q(double x, double shift, const double *y, int x_length,
   delete[] delta_y;
 }
 
-// You must not use these variables.
-// Note:
-// I have no idea to implement the randn() and randn_reseed() without the
-// global variables. If you have a good idea, please give me the information.
-static uint32_t g_randn_x = 123456789;
-static uint32_t g_randn_y = 362436069;
-static uint32_t g_randn_z = 521288629;
-static uint32_t g_randn_w = 88675123;
-
-void randn_reseed() {
-    g_randn_x = 123456789;
-    g_randn_y = 362436069;
-    g_randn_z = 521288629;
-    g_randn_w = 88675123;
+void randn_reseed(RandnState *state) {
+    state->g_randn_x = 123456789;
+    state->g_randn_y = 362436069;
+    state->g_randn_z = 521288629;
+    state->g_randn_w = 88675123;
 }
 
-double randn(void) {
+double randn(RandnState *state) {
   uint32_t t;
-  t = g_randn_x ^ (g_randn_x << 11);
-  g_randn_x = g_randn_y;
-  g_randn_y = g_randn_z;
-  g_randn_z = g_randn_w;
-  g_randn_w = (g_randn_w ^ (g_randn_w >> 19)) ^ (t ^ (t >> 8));
+  t = state->g_randn_x ^ (state->g_randn_x << 11);
+  state->g_randn_x = state->g_randn_y;
+  state->g_randn_y = state->g_randn_z;
+  state->g_randn_z = state->g_randn_w;
+  state->g_randn_w
+    = (state->g_randn_w ^ (state->g_randn_w >> 19)) ^ (t ^ (t >> 8));
 
-  uint32_t tmp = g_randn_w >> 4;
+  uint32_t tmp = state->g_randn_w >> 4;
   for (int i = 0; i < 11; ++i) {
-    t = g_randn_x ^ (g_randn_x << 11);
-    g_randn_x = g_randn_y;
-    g_randn_y = g_randn_z;
-    g_randn_z = g_randn_w;
-    g_randn_w = (g_randn_w ^ (g_randn_w >> 19)) ^ (t ^ (t >> 8));
-    tmp += g_randn_w >> 4;
+    t = state->g_randn_x ^ (state->g_randn_x << 11);
+    state->g_randn_x = state->g_randn_y;
+    state->g_randn_y = state->g_randn_z;
+    state->g_randn_z = state->g_randn_w;
+    state->g_randn_w
+      = (state->g_randn_w ^ (state->g_randn_w >> 19)) ^ (t ^ (t >> 8));
+    tmp += state->g_randn_w >> 4;
   }
   return tmp / 268435456.0 - 6.0;
 }

--- a/src/synthesis.cpp
+++ b/src/synthesis.cpp
@@ -17,10 +17,10 @@
 namespace {
 
 static void GetNoiseSpectrum(int noise_size, int fft_size,
-    const ForwardRealFFT *forward_real_fft) {
+    const ForwardRealFFT *forward_real_fft, RandnState *randn_state) {
   double average = 0.0;
   for (int i = 0; i < noise_size; ++i) {
-    forward_real_fft->waveform[i] = randn();
+    forward_real_fft->waveform[i] = randn(randn_state);
     average += forward_real_fft->waveform[i];
   }
 
@@ -39,8 +39,9 @@ static void GetAperiodicResponse(int noise_size, int fft_size,
     const double *spectrum, const double *aperiodic_ratio, double current_vuv,
     const ForwardRealFFT *forward_real_fft,
     const InverseRealFFT *inverse_real_fft,
-    const MinimumPhaseAnalysis *minimum_phase, double *aperiodic_response) {
-  GetNoiseSpectrum(noise_size, fft_size, forward_real_fft);
+    const MinimumPhaseAnalysis *minimum_phase, double *aperiodic_response,
+    RandnState *randn_state) {
+  GetNoiseSpectrum(noise_size, fft_size, forward_real_fft, randn_state);
 
   if (current_vuv != 0.0)
     for (int i = 0; i <= minimum_phase->fft_size / 2; ++i)
@@ -187,7 +188,7 @@ static void GetOneFrameSegment(double current_vuv, int noise_size,
     const ForwardRealFFT *forward_real_fft,
     const InverseRealFFT *inverse_real_fft,
     const MinimumPhaseAnalysis *minimum_phase, const double *dc_remover,
-    double *response) {
+    double *response, RandnState* randn_state) {
   double *aperiodic_response = new double[fft_size];
   double *periodic_response = new double[fft_size];
 
@@ -206,7 +207,7 @@ static void GetOneFrameSegment(double current_vuv, int noise_size,
   // Synthesis of the aperiodic response
   GetAperiodicResponse(noise_size, fft_size, spectral_envelope,
       aperiodic_ratio, current_vuv, forward_real_fft,
-      inverse_real_fft, minimum_phase, aperiodic_response);
+      inverse_real_fft, minimum_phase, aperiodic_response, randn_state);
 
   double sqrt_noise_size = sqrt(static_cast<double>(noise_size));
   for (int i = 0; i < fft_size; ++i)
@@ -338,7 +339,8 @@ static void GetDCRemover(int fft_size, double *dc_remover) {
 void Synthesis(const double *f0, int f0_length,
     const double * const *spectrogram, const double * const *aperiodicity,
     int fft_size, double frame_period, int fs, int y_length, double *y) {
-  randn_reseed();
+  RandnState randn_state = {};
+  randn_reseed(&randn_state);
 
   double *impulse_response = new double[fft_size];
 
@@ -373,7 +375,7 @@ void Synthesis(const double *f0, int f0_length,
         spectrogram, fft_size, aperiodicity, f0_length, frame_period,
         pulse_locations[i], pulse_locations_time_shift[i], fs,
         &forward_real_fft, &inverse_real_fft, &minimum_phase, dc_remover,
-        impulse_response);
+        impulse_response, &randn_state);
     offset = pulse_locations_index[i] - fft_size / 2 + 1;
     lower_limit = MyMaxInt(0, -offset);
     upper_limit = MyMinInt(fft_size, y_length - offset);

--- a/src/world/matlabfunctions.h
+++ b/src/world/matlabfunctions.h
@@ -6,6 +6,8 @@
 #ifndef WORLD_MATLABFUNCTIONS_H_
 #define WORLD_MATLABFUNCTIONS_H_
 
+#include <stdint.h>
+
 #include "world/common.h"
 #include "world/macrodefinitions.h"
 
@@ -125,19 +127,26 @@ void diff(const double *x, int x_length, double *y);
 void interp1Q(double x, double shift, const double *y, int x_length,
   const double *xi, int xi_length, double *yi);
 
+typedef struct {
+  uint32_t g_randn_x;
+  uint32_t g_randn_y;
+  uint32_t g_randn_z;
+  uint32_t g_randn_w;
+} RandnState;
+
 //-----------------------------------------------------------------------------
 // randn() generates pseudorandom numbers based on xorshift method.
 //
 // Output:
 //   A generated pseudorandom number
 //-----------------------------------------------------------------------------
-double randn(void);
+double randn(RandnState *state);
 
 //-----------------------------------------------------------------------------
 // randn_reseed() forces to seed the pseudorandom generator using initial
 // values.
 //-----------------------------------------------------------------------------
-void randn_reseed(void);
+void randn_reseed(RandnState *state);
 
 //-----------------------------------------------------------------------------
 // fast_fftfilt() carries out the convolution on the frequency domain.

--- a/src/world/synthesisrealtime.h
+++ b/src/world/synthesisrealtime.h
@@ -8,6 +8,7 @@
 
 #include "world/common.h"
 #include "world/macrodefinitions.h"
+#include "world/matlabfunctions.h"
 
 WORLD_BEGIN_C_DECLS
 
@@ -66,6 +67,8 @@ typedef struct {
   int *number_of_pulses;
 
   double *impulse_response;
+
+  RandnState randn_state;
 
   // FFT
   MinimumPhaseAnalysis minimum_phase;


### PR DESCRIPTION
Change `randn()` so that it does not use global variables.
If the state of randn is the same, the output will be the same as before the change.